### PR TITLE
Fix sharp dependency in node 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
-    "sharp": "^0.22.0"
+    "sharp": "^0.23.2"
   },
   "devDependencies": {
     "prettier": "^1.16.4"


### PR DESCRIPTION
It currently fails for me (both windows and ubuntu):
> npm ERR! Failed at the sharp@0.22.1 install script.