### PR TITLE
Upgrade sharp and gatsby-plugin-sharp dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gatsby-image": "^2.0.34",
     "gatsby-plugin-google-analytics": "^2.0.17",
     "gatsby-plugin-react-helmet": "^3.0.10",
-    "gatsby-plugin-sharp": "^2.0.29",
+    "gatsby-plugin-sharp": "^4.8.0",
     "gatsby-plugin-sitemap": "^2.0.10",
     "gatsby-source-filesystem": "^2.0.27",
     "gatsby-transformer-sharp": "^2.1.17",
@@ -17,7 +17,7 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-helmet": "^5.2.0",
-    "sharp": "^0.22.0"
+    "sharp": "^0.30.1"
   },
   "devDependencies": {
     "prettier": "^1.16.4"


### PR DESCRIPTION
### Reference issues
Might fix gh-12, gh-19 and gh-32

### What does this implement/fix?
The initial `npm install` or `gatsby new landing-page https://github.com/gillkyle/gatsby-starter-landing-page.git` has an image rendering dependency that fails:

<img width="1587" alt="Screen Shot 2022-02-23 at 5 04 44 PM" src="https://user-images.githubusercontent.com/2831414/155432750-2d732c47-4c60-49d5-97b1-b30a25b97c15.png">

Upgrading both sharp and gatsby's plugin to the latest versions fixes this issue:

<img width="1842" alt="Screen Shot 2022-02-23 at 5 10 13 PM" src="https://user-images.githubusercontent.com/2831414/155432788-57e3ef6b-5abc-4c00-9394-56fd73ab7448.png">

### Any other comments?
No